### PR TITLE
Set cron job file(s) permission to 600

### DIFF
--- a/install_vpn_router.sh
+++ b/install_vpn_router.sh
@@ -259,6 +259,7 @@ function process_project_files {
   # The symlink is not included, but it doesn't have (meaningful) permissions.
   find "$v_project_path/configfiles" -type d -exec chmod 755 {} \;
   find "$v_project_path/configfiles" -type f -name '*.sh' -exec chmod 755 {} \;
+  find "$v_project_path/configfiles/etc/cron.d" -type f -exec chmod 600 {} \;
   find "$v_project_path/configfiles" -type f -not -name '*.sh' -exec chmod 644 {} \;
 }
 


### PR DESCRIPTION
Cron job files need to be 600, otherwise, a warning is printed in the syslog.